### PR TITLE
Added changes for attaching data volumes to store NBDE data

### DIFF
--- a/modules/2_nbde/files/volume-mount.yaml
+++ b/modules/2_nbde/files/volume-mount.yaml
@@ -1,0 +1,26 @@
+- name: playbook for mounting data volume
+  hosts: all
+  become: true
+  tasks:
+    - name: Create directory /var/db/tang if does not exist
+      file:
+        path: /var/db/tang
+        state: directory
+        mode: '0755'
+        recurse: yes
+    - name: create partition
+      parted:
+        device: /dev/mapper/mpathb
+        number: 1
+        flags: [ lvm ]
+        state: present
+        part_end: "{{ volume_size }}GB"
+    - name: format the partition
+      shell: |
+        sudo mkfs.ext4 /dev/mapper/mpathb1
+    - name: mount the lv on /var/db/tang
+      mount:
+        path: /var/db/tang
+        src: /dev/mapper/mpathb1
+        fstype: ext4
+        state: mounted

--- a/modules/2_nbde/variables.tf
+++ b/modules/2_nbde/variables.tf
@@ -182,12 +182,16 @@ variable "tang" {
     # optional fixed IPs
     # fixed_ips = []
     # optional data volumes to master nodes
-    # data_volume_size = 100 #Default volume size (in GB) to be attached to the master nodes.
-    # data_volume_count = 0 #Number of volumes to be attached to each master node.
+    data_volume_size  = 10 #Default volume size (in GB) to be attached to the Tang servers.
+    data_volume_count = 1  #Number of volumes to be attached to each Tang server.
   }
   validation {
     condition     = lookup(var.tang, "count", 3) == 3
     error_message = "The tang.count value must be 3."
+  }
+  validation {
+    condition     = lookup(var.tang, "data_volume_count", 1) == 1
+    error_message = "The tang.data_volume_count must be 1."
   }
 }
 

--- a/var.tfvars
+++ b/var.tfvars
@@ -16,9 +16,11 @@ bastion = {
   count         = 1
 }
 tang = {
-  image_id      = "27ebd00f-cbec-4e27-993d-56e4bd441584"
-  instance_type = "base-ocp-squad-tiny"
-  count         = 3
+  image_id          = "27ebd00f-cbec-4e27-993d-56e4bd441584"
+  instance_type     = "base-ocp-squad-tiny"
+  count             = 3
+  data_volume_count = 1
+  data_volume_size  = 10
 }
 domain = "sslip.io"
 

--- a/variables.tf
+++ b/variables.tf
@@ -90,12 +90,16 @@ variable "tang" {
     # optional fixed IPs
     # fixed_ips = []
     # optional data volumes to master nodes
-    # data_volume_size = 100 #Default volume size (in GB) to be attached to the master nodes.
-    # data_volume_count = 0 #Number of volumes to be attached to each master node.
+    data_volume_size  = 10 #Default volume size (in GB) to be attached to the master nodes.
+    data_volume_count = 1  #Number of volumes to be attached to each master node.
   }
   validation {
     condition     = lookup(var.tang, "count", 3) == 3
     error_message = "The tang.count value must be 3."
+  }
+  validation {
+    condition     = lookup(var.tang, "data_volume_count", 1) == 1
+    error_message = "The tang.data_volume_count must be 1."
   }
 }
 


### PR DESCRIPTION
This PR is consisting of all the code changes which will help in attaching data volumes each of size 10GB to each tang server.
Also included ansible-playbook code to create & mount the partition /data/tangdata to store NBDE data i.e. keys in *.jwk format on each tang server.

Each tang server will also have thumbprints in /root/tmp.txt file.